### PR TITLE
Add getIntent() api for using with ActivityResultLauncher

### DIFF
--- a/matisse/build.gradle
+++ b/matisse/build.gradle
@@ -27,7 +27,7 @@ android {
         targetSdkVersion 29
 
         versionCode 19
-        versionName "0.5.3-beta307"
+        versionName "0.5.3-beta308"
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
+++ b/matisse/src/main/java/com/zhihu/matisse/SelectionCreator.java
@@ -364,6 +364,14 @@ public final class SelectionCreator {
         }
     }
 
+    public Intent getIntent() {
+        Activity activity = mMatisse.getActivity();
+        if (activity == null) {
+            return null;
+        }
+        return new Intent(activity, MatisseActivity.class);
+    }
+
     public SelectionCreator showPreview(boolean showPreview) {
         mSelectionSpec.showPreview = showPreview;
         return this;


### PR DESCRIPTION
We want to start Matisse using ActivityResultLauncher https://developer.android.com/training/basics/intents/result.

So we need an API for creating Intent for Matisse